### PR TITLE
Refine additional grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![travis-status][travis-status]][travis-project]
 [![dependency-status][david-status]][david-project]
 
-Atom-IDE support for HTML language
+Atom-IDE support for HTML language including Handlebars, Mustache.
 
 ![demo-outline-1][demo-outline-1]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ide-html",
   "version": "0.1.2",
-  "description": "Atom-IDE support for HTML language",
+  "description": "Atom-IDE support for HTML language including Handlebars, Mustache",
   "main": "src/main.js",
   "scripts": {
     "eslint": "eslint ./src",
@@ -12,6 +12,9 @@
     "atom-ide",
     "html",
     "html-parsing",
+    "html-template",
+    "handlebars",
+    "mustache",
     "ide",
     "language-server-protocol",
     "outline-view"
@@ -78,9 +81,9 @@
   "configSchema": {
     "additionalGrammars": {
       "type": "array",
-      "title": "Register Additional Grammars",
+      "title": "Register Additional Grammars (Experimental)",
       "default": [],
-      "description": "**Experimental** Register additional html grammars such as text.html.handlebars or text.html.mustache. Add comma delimited values with no spaces. ex: text.html.handlebars,text.html.mustache"
+      "description": "Register additional html grammars such as **handlebars** or **mustache** in comma delimited format.</br>e.g. `text.html.handlebars, text.html.mustache`</br>Please do `Window:Reload` to apply changes."
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ const path = require('path')
 const { AutoLanguageClient } = require('atom-languageclient')
 
 class HTMLLanguageClient extends AutoLanguageClient {
-  getGrammarScopes () { return atom.config.get('ide-html.additionalGrammars').concat(['text.html.basic']); }
+  getGrammarScopes () { return atom.config.get('ide-html.additionalGrammars').concat(['text.html.basic']) }
   getLanguageName () { return 'HTML' }
   getServerName () { return 'VSCODE-HTML-LANG-SERVER' }
   getConnectionType() { return 'stdio' } // ipc, socket, stdio


### PR DESCRIPTION
refine #4

- fix linter error
- reword on description of external grammar support
- add description in README, package.json