### PR TITLE
Added Angular (text.html.ng) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "enhancedScopes": [
     "text.html.basic",
+    "text.html.ng",
     "text.html.gohtml",
     "text.html.mustache"
   ],

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ class HTMLLanguageClient extends AutoLanguageClient {
       gohtmlSupport,
       mustacheSupport,
     } = atom.config.get('ide-html')
-    return ['text.html.basic']
+    return ['text.html.basic', 'text.html.ng']
       .concat(gohtmlSupport ? 'text.html.gohtml' : [])
       .concat(mustacheSupport ? 'text.html.mustache' : [])
       .concat(additionalGrammars || [])


### PR DESCRIPTION
It already works when I put `text.html.ng` in additional grammars, however I thought this option is for optional extensions like backend languages. `text.html.ng` is always a frontend code, and no problem to put it in defaults.

By the way, `text.html.ng` is from [language-html-angular](https://github.com/drootz/language-html-angular) package.