### PR TITLE
feat(cmd): better navigation to settings via Uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     }
   },
   "atomCommands": {
-    "ide-html:help": "Provides help information and descriptions of commands."
+    "ide-html:help": "Provides help information and descriptions of commands.",
+    "ide-html:open-settings": "Open settings page."
   },
   "configSchema": {
     "additionalGrammars": {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { AutoLanguageClient } = require('atom-languageclient')
-const { registerConfigOnChangeHandlers } = require('./util')
+const { registerConfigOnChangeHandlers, registerOpenSettingsCommand } = require('./util')
 const { registerHelpCommands } = require('./help_cmd')
 const { showWelcomeNotification } = require('./welcome_notification')
 
@@ -8,6 +8,7 @@ class HTMLLanguageClient extends AutoLanguageClient {
   constructor() {
     super()
     registerConfigOnChangeHandlers()
+    registerOpenSettingsCommand()
     registerHelpCommands()
     showWelcomeNotification()
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,17 @@
+const packageJSON = require('../package.json')
+
 const registerConfigOnChangeHandlers = () => {
   atom.config.onDidChange('ide-html.additionalGrammars', () =>
     promptUserReloadAtom('Reload `ide-html` to apply additional grammars')
   )
   atom.config.onDidChange('ide-html.jspSupport', () => promptUserReloadAtom() )
   atom.config.onDidChange('ide-html.mustacheSupport', () => promptUserReloadAtom() )
+}
+
+const registerOpenSettingsCommand = () => {
+  atom.commands.add('atom-workspace', `${packageJSON.name}:open-settings`, () => {
+    atom.workspace.open(`atom://config/packages/${packageJSON.name}`)
+  })
 }
 
 const promptUserReloadAtom = (msg = 'Reload `ide-html` to apply changes') => {
@@ -22,5 +30,6 @@ const promptUserReloadAtom = (msg = 'Reload `ide-html` to apply changes') => {
 
 module.exports = {
   registerConfigOnChangeHandlers,
+  registerOpenSettingsCommand,
   promptUserReloadAtom,
 }

--- a/src/welcome_notification.js
+++ b/src/welcome_notification.js
@@ -34,10 +34,7 @@ const settingsButton = [
   {
     text: ' Open Settings Page',
     onDidClick: () => {
-      atom.commands.dispatch(
-        atom.views.getView(atom.workspace.getActivePane()),
-        'settings-view:install-packages-and-themes'
-      )
+      atom.workspace.open('atom://config/install/package:atom-ide-ui')
     },
     className: 'btn btn-success btn-lg icon-tools',
   },


### PR DESCRIPTION
- add command to navigate user to settings page
- navigate user to package installation page to prompt install atom-ide-ui

Ref: http://flight-manual.atom.io/hacking-atom/sections/handling-uris/