### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+/.github export-ignore
+/.eslintignore export-ignore
+/.eslintrc.yml export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/.renovaterc.json export-ignore
+/.travis.yml export-ignore
+/CONTRIBUTING.md export-ignore
+/yarn.lock export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).
