### PR TITLE
Add PHP HTML support setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,12 @@
       "title": "Mustache, Handlebars Language Support",
       "default": true,
       "description": "Support files with `.mustache` `.handlebars` extension."
+    },
+    "phphtmlSupport": {
+      "type": "boolean",
+      "title": "PHP Template Language Support",
+      "default": true,
+      "description": "Support files with `.php` extension."
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -15,10 +15,12 @@ class HTMLLanguageClient extends AutoLanguageClient {
       additionalGrammars,
       gohtmlSupport,
       mustacheSupport,
+      phphtmlSupport,
     } = atom.config.get('ide-html')
-    return ['text.html.basic', 'text.html.php']
+    return ['text.html.basic']
       .concat(gohtmlSupport ? 'text.html.gohtml' : [])
       .concat(mustacheSupport ? 'text.html.mustache' : [])
+      .concat(phphtmlSupport ? 'text.html.php' : [])
       .concat(additionalGrammars || [])
   }
   getLanguageName () { return 'HTML' }

--- a/src/util.js
+++ b/src/util.js
@@ -6,6 +6,7 @@ const registerConfigOnChangeHandlers = () => {
   )
   atom.config.onDidChange('ide-html.jspSupport', () => promptUserReloadAtom() )
   atom.config.onDidChange('ide-html.mustacheSupport', () => promptUserReloadAtom() )
+  atom.config.onDidChange('ide-html.phphtmlSupport', () => promptUserReloadAtom())
 }
 
 const registerOpenSettingsCommand = () => {


### PR DESCRIPTION
## Description
This PR adds an option to disable PHP file extensions so that users can work around issue #41 .

## Motivation and Context
This PR adds a functional workaround for the issues reported in #41.

## How Has This Been Tested?
I have built and tested the change locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.
